### PR TITLE
feat: add ignore-filename-regex input for filtering coverage files

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Default: `'false'`
 If `true`, the action fails if no coverage files were found (output is still set to an empty array).<br/>
 Default: `'false'`
 
+### `ignore-filename-regex`
+
+A regular expression that is used to filter coverage files by their filenames.
+
 ## Outputs
 
 ### `files`

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ inputs:
     description: If `true`, the action fails if no coverage files were found (output is still set to an empty array).
     required: true
     default: 'false'
+  ignore-filename-regex:
+    description: A regular expression that is used to filter coverage files by their filenames.
+    required: false
 outputs:
   files:
     description: The JSON-encoded array of (absolute) file paths that were converted.

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,10 +18,10 @@ enum CovFormat {
 }
 
 declare type WalkEntry = {
-  path: string;
-  isDirectory: boolean;
+    path: string;
+    isDirectory: boolean;
 
-  skipDescendants(): void;
+    skipDescendants(): void;
 };
 
 // Taken and adjusted from https://stackoverflow.com/a/65415138/1388842
@@ -36,7 +36,7 @@ async function* walk(dir: string, onlyFiles: boolean = true): AsyncGenerator<Wal
             if (!skipDesc)
                 yield* walk(res, onlyFiles);
         } else {
-            yield { path: res, isDirectory: false, skipDescendants: () => {} };
+            yield { path: res, isDirectory: false, skipDescendants: () => { } };
         }
     }
 }
@@ -62,7 +62,7 @@ async function main() {
 
     core.startGroup('Validating input');
     const searchPaths = core.getMultilineInput('search-paths', { required: true })
-            .map(p => path.resolve(p.replace(/(~|\$HOME|\${HOME})/g, os.homedir)));
+        .map(p => path.resolve(p.replace(/(~|\$HOME|\${HOME})/g, os.homedir)));
     const outputFolder = path.resolve(core.getInput('output', { required: true })
         .replace(/(~|\$HOME|\${HOME})/g, os.homedir));
     const _format = core.getInput('format', { required: true })
@@ -72,6 +72,8 @@ async function main() {
     const targetNameFilter = _targetNameFilter ? new RegExp(_targetNameFilter) : null;
     const ignoreConversionFailures = core.getBooleanInput('ignore-conversion-failures');
     const failOnEmptyOutput = core.getBooleanInput('fail-on-empty-output');
+    const _ignoreFilenameRegex = core.getInput('ignore-filename-regex');
+    const ignoreFilenameRegex = _ignoreFilenameRegex ? new RegExp(_ignoreFilenameRegex) : null;
     core.endGroup();
 
     await core.group('Setting up paths', async () => {
@@ -175,6 +177,9 @@ async function main() {
                             break;
                     }
                     args.push('-instr-profile', profDataFile, dest);
+                    if (ignoreFilenameRegex) { 
+                        args.push('-ignore-filename-regex', ignoreFilenameRegex.toString()); 
+                    }
                     let converted: string;
                     try {
                         converted = await runCmd(cmd, ...args);


### PR DESCRIPTION
I’ve made a small change to my project that might be useful for others. I’ve added an input parameter called `ignore-filename-regex` to the `llvm-cov` command. If you’re interested in merging it, I’ve pushed it upstream.

Here are the changes I made:

1. I added the `ignore-filename-regex` input parameter to the `action.yml` file.
2. I updated the `README.md` documentation to explain the new parameter.
3. I implemented the filename filtering logic in the `main.ts` file using regular expressions.